### PR TITLE
Set for remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-lightning-design-system-with-remote",
-  "version": "0.2.4-1",
+  "name": "react-lightning-design-system",
+  "version": "0.2.4",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "directories": {
@@ -32,7 +32,7 @@
   "files": [
     "lib"
   ],
-  "author": "Eyal Eizenberg <eyal.eizenberg@samanage.com>",
+  "author": "Shinichi Tomita <shinichi.tomita@gmail.com>",
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^6.3.19",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-lightning-design-system",
+  "name": "react-lightning-design-system-with-remote",
   "version": "0.2.4",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
@@ -32,7 +32,7 @@
   "files": [
     "lib"
   ],
-  "author": "Shinichi Tomita <shinichi.tomita@gmail.com>",
+  "author": "Eyal Eizenberg <eyal.eizenberg@samanage.com>",
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^6.3.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-system-with-remote",
-  "version": "0.2.4",
+  "version": "0.2.4-1",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "directories": {

--- a/src/scripts/Picklist.js
+++ b/src/scripts/Picklist.js
@@ -103,7 +103,7 @@ export default class Picklist extends React.Component {
         selected = item.props.label || item.props.children;
       }
     });
-    return selected;
+    return (selected || this.props.selectedText);
   }
 
   isFocusedInComponent() {
@@ -182,6 +182,7 @@ Picklist.propTypes = {
   name: PropTypes.string,
   value: PropTypes.any,
   defaultValue: PropTypes.any,
+  selectedText: PropTypes.string,
   defaultOpened: PropTypes.bool,
   onChange: PropTypes.func,
   onValueChange: PropTypes.func,
@@ -218,6 +219,6 @@ PicklistItem.propTypes = {
     PropTypes.number,
   ]),
   selected: PropTypes.bool,
-  value: PropTypes.number,
+  value: PropTypes.any,
   children: PropTypes.node,
 };


### PR DESCRIPTION
This PR gives to the ability to:
1. Set a value in the picklist even if it's not in the picklist items yet. (I am fetching the options from the server only when the list opens).

2. Set the value to 'any'. Ids in SF are strings, so we should be able to accept both strings and integers.