### PR TITLE
Added support for validation to Input & Textarea

### DIFF
--- a/examples/client/scripts/components/FormExamples.js
+++ b/examples/client/scripts/components/FormExamples.js
@@ -194,16 +194,16 @@ export default class FormExamples extends React.Component {
         <div>Mark input and textarea as required. Uses component validation.</div>
         <div style={ styles }>
           <Form>
-            <Input label='Name' placeholder='Name' value={ this.state.value_Input } required={ true } validate={ true } onChange={ this.onValidate.bind(this, 'Input') } />
-            <Textarea label='Description' placeholder='Description' value={ this.state.value_TextArea } required={ true } validate={ true } onChange={ this.onValidate.bind(this, 'TextArea') } />
+            <Input label='Name' placeholder='Name' value={ this.state.value_Input } required validate onChange={ this.onValidate.bind(this, 'Input') } />
+            <Textarea label='Description' placeholder='Description' value={ this.state.value_TextArea } required validate onChange={ this.onValidate.bind(this, 'TextArea') } />
           </Form>
         </div>
         <div>Mark input and textarea as required. Mark as valid using valid props.</div>
         <div style={ styles }>
           <Form>
             <Checkbox label='Toggle Validation' checked={ this.state.isValid } onChange={ (event) => this.setState({ isValid: event.target.checked }) } />
-            <Input label='Name' placeholder='Name' required={ true } valid={ this.state.isValid } />
-            <Textarea label='Description' placeholder='Description' required={ true } valid={ this.state.isValid } />
+            <Input label='Name' placeholder='Name' required valid={ this.state.isValid } />
+            <Textarea label='Description' placeholder='Description' required valid={ this.state.isValid } />
           </Form>
         </div>
 

--- a/examples/client/scripts/components/FormExamples.js
+++ b/examples/client/scripts/components/FormExamples.js
@@ -21,12 +21,25 @@ export default class FormExamples extends React.Component {
       select: 2,
       picklist: 2,
       dateinput: '2015-12-24',
+      isValid: false,
+
+      value_Input: 'Text1',
+      value_TextArea: 'Text2',
+      valid_Input: true,
+      valid_TextArea: true,
     };
   }
 
   onFieldChange(name, e, value) {
     console.log(name, value);
     this.setState({ [name]: value });
+  }
+
+  onValidate(key, event, value, valid) {
+    this.setState({
+      ['value_' + key]: value,
+      ['valid_' + key]: valid,
+    });
   }
 
   render() {
@@ -176,6 +189,24 @@ export default class FormExamples extends React.Component {
             </FieldSet>
           </Form>
         </div>
+
+        <h2 className='slds-m-vertical--medium'>Form Validation</h2>
+        <div>Mark input and textarea as required. Uses component validation.</div>
+        <div style={ styles }>
+          <Form>
+            <Input label='Name' placeholder='Name' value={ this.state.value_Input } required={ true } validate={ true } onChange={ this.onValidate.bind(this, 'Input') } />
+            <Textarea label='Description' placeholder='Description' value={ this.state.value_TextArea } required={ true } validate={ true } onChange={ this.onValidate.bind(this, 'TextArea') } />
+          </Form>
+        </div>
+        <div>Mark input and textarea as required. Mark as valid using valid props.</div>
+        <div style={ styles }>
+          <Form>
+            <Checkbox label='Toggle Validation' checked={ this.state.isValid } onChange={ (event) => this.setState({ isValid: event.target.checked }) } />
+            <Input label='Name' placeholder='Name' required={ true } valid={ this.state.isValid } />
+            <Textarea label='Description' placeholder='Description' required={ true } valid={ this.state.isValid } />
+          </Form>
+        </div>
+
       </div>
     );
   }

--- a/src/scripts/FormElement.js
+++ b/src/scripts/FormElement.js
@@ -22,7 +22,7 @@ export default class FormElement extends React.Component {
   }
 
   renderFormElement(props) {
-    const { className, label, valid, validationMessage, totalCols, ...pprops } = props;
+    const { className, label, valid, required, totalCols, ...pprops } = props;
     const inputId = props.id || this.state.id;
     if (typeof totalCols === 'number') {
       return (
@@ -38,13 +38,18 @@ export default class FormElement extends React.Component {
     }
 
     const formElementClassName = classnames(
-      'slds-form-element',
-      'slds-has-error': !valid,
-      'slds-is-required': !valid
+      'slds-form-element', {
+        'slds-has-error': (valid === false),
+        'slds-is-required': (required === true),
+      }
     );
 
-    const formElementValidationMessage = (!valid) 
-      ? (<span className='slds-form-element__help'>This field is required</span>) 
+    const validationMessage = (!!props.validationMessage)
+      ? props.validationMessage
+      : 'This field is required';
+
+    const formElementValidationMessage = (valid === false)
+      ? (<span className='slds-form-element__help'>{ validationMessage }</span>)
       : null;
 
     return (
@@ -94,13 +99,9 @@ FormElement.propTypes = {
   className: PropTypes.string,
   cols: PropTypes.number,
   children: PropTypes.element,
+  required: PropTypes.bool,
   valid: PropTypes.bool,
   validationMessage: PropTypes.string,
 };
 
-Form.defaultProps = {
-  valid: true,
-};
-
 FormElement.isFormElement = true;
-

--- a/src/scripts/FormElement.js
+++ b/src/scripts/FormElement.js
@@ -22,7 +22,7 @@ export default class FormElement extends React.Component {
   }
 
   renderFormElement(props) {
-    const { className, label, totalCols, ...pprops } = props;
+    const { className, label, valid, validationMessage, totalCols, ...pprops } = props;
     const inputId = props.id || this.state.id;
     if (typeof totalCols === 'number') {
       return (
@@ -37,8 +37,18 @@ export default class FormElement extends React.Component {
       );
     }
 
+    const formElementClassName = classnames(
+      'slds-form-element',
+      'slds-has-error': !valid,
+      'slds-is-required': !valid
+    );
+
+    const formElementValidationMessage = (!valid) 
+      ? (<span className='slds-form-element__help'>This field is required</span>) 
+      : null;
+
     return (
-      <div className='slds-form-element'>
+      <div className={ formElementClassName }>
         {
           label ?
           <label className='slds-form-element__label' htmlFor={ inputId }>{ label }</label> :
@@ -47,6 +57,9 @@ export default class FormElement extends React.Component {
         <div className={ className }>
           { this.props.children }
         </div>
+
+        { formElementValidationMessage }
+
       </div>
     );
   }
@@ -81,6 +94,13 @@ FormElement.propTypes = {
   className: PropTypes.string,
   cols: PropTypes.number,
   children: PropTypes.element,
+  valid: PropTypes.bool,
+  validationMessage: PropTypes.string,
+};
+
+Form.defaultProps = {
+  valid: true,
 };
 
 FormElement.isFormElement = true;
+

--- a/src/scripts/Input.js
+++ b/src/scripts/Input.js
@@ -12,10 +12,10 @@ export default class Input extends React.Component {
   }
 
   render() {
-    const { label, ...props } = this.props;
+    const { label, valid, validationMessage, ...props } = this.props;
     if (label) {
       return (
-        <FormElement id={ props.id } label={ label }>
+        <FormElement id={ props.id } label={ label } valid={ valid } validationMessage={ validationMessage }>
           <Input { ...props } />
         </FormElement>
       );
@@ -40,4 +40,6 @@ Input.propTypes = {
   defaultValue: PropTypes.any,
   placeholder: PropTypes.string,
   onChange: PropTypes.func,
+  valid: PropTypes.bool,
+  validationMessage: PropTypes.string
 };

--- a/src/scripts/Input.js
+++ b/src/scripts/Input.js
@@ -4,22 +4,33 @@ import FormElement from './FormElement';
 
 
 export default class Input extends React.Component {
+
   onChange(e) {
     const value = e.target.value;
+    const valid = this.validate(this.props, value);
+
     if (this.props.onChange) {
-      this.props.onChange(e, value);
+      this.props.onChange(e, value, valid);
     }
   }
 
+  validate(props, value) {
+    const inputValue = (value !== undefined) ? value : props.value;
+    return ((inputValue !== null && inputValue.trim().length !== 0) ? true : false);
+  }
+
   render() {
-    const { label, valid, validationMessage, ...props } = this.props;
+    const { label, required, validate, validationMessage, ...props } = this.props;
+    const isValid = (validate === true) ? this.validate(this.props) : true;
+
     if (label) {
       return (
-        <FormElement id={ props.id } label={ label } valid={ valid } validationMessage={ validationMessage }>
+        <FormElement id={ props.id } label={ label } required={ required } valid={ isValid } validationMessage={ validationMessage }>
           <Input { ...props } />
         </FormElement>
       );
     }
+
     const { className, id, type, onChange, ...pprops } = props;
     const inputClassNames = classnames(className, 'slds-input');
     return (
@@ -40,6 +51,13 @@ Input.propTypes = {
   defaultValue: PropTypes.any,
   placeholder: PropTypes.string,
   onChange: PropTypes.func,
-  valid: PropTypes.bool,
-  validationMessage: PropTypes.string
+  required: PropTypes.bool,
+  validate: PropTypes.bool,
+  validationMessage: PropTypes.string,
 };
+
+Input.defaultProps = {
+  validationMessage: 'This field is required',
+};
+
+Input.isFormElement = true;

--- a/src/scripts/Input.js
+++ b/src/scripts/Input.js
@@ -16,12 +16,12 @@ export default class Input extends React.Component {
 
   validate(props, value) {
     const inputValue = (value !== undefined) ? value : props.value;
-    return ((inputValue !== null && inputValue.trim().length !== 0) ? true : false);
+    return ((inputValue !== undefined && inputValue !== null && inputValue.trim().length !== 0) ? true : false);
   }
 
   render() {
-    const { label, required, validate, validationMessage, ...props } = this.props;
-    const isValid = (validate === true) ? this.validate(this.props) : true;
+    const { label, required, validate, valid, validationMessage, ...props } = this.props;
+    const isValid = valid || (validate === true) ? this.validate(this.props) : true;
 
     if (label) {
       return (
@@ -52,6 +52,7 @@ Input.propTypes = {
   placeholder: PropTypes.string,
   onChange: PropTypes.func,
   required: PropTypes.bool,
+  valid: PropTypes.bool,
   validate: PropTypes.bool,
   validationMessage: PropTypes.string,
 };

--- a/src/scripts/Textarea.js
+++ b/src/scripts/Textarea.js
@@ -4,18 +4,28 @@ import FormElement from './FormElement';
 
 
 export default class Textarea extends React.Component {
+
   onChange(e) {
     const value = e.target.value;
+    const valid = this.validate(this.props, value);
+
     if (this.props.onChange) {
-      this.props.onChange(e, value);
+      this.props.onChange(e, value, valid);
     }
   }
 
+  validate(props, value) {
+    const inputValue = (value !== undefined) ? value : props.value;
+    return ((inputValue !== null && inputValue.trim().length !== 0) ? true : false);
+  }
+
   render() {
-    const { label, ...props } = this.props;
+    const { label, required, validate, validationMessage, ...props } = this.props;
+    const isValid = (validate === true) ? this.validate(this.props) : true;
+
     if (label) {
       return (
-        <FormElement>
+        <FormElement id={ props.id } label={ label } required={ required } valid={ isValid } validationMessage={ validationMessage }>
           <Textarea { ...props } />
         </FormElement>
       );
@@ -39,4 +49,13 @@ Textarea.propTypes = {
   placeholder: PropTypes.string,
   label: PropTypes.string,
   onChange: PropTypes.func,
+  required: PropTypes.bool,
+  validate: PropTypes.bool,
+  validationMessage: PropTypes.string,
 };
+
+Textarea.defaultProps = {
+  validationMessage: 'This field is required',
+};
+
+Textarea.isFormElement = true;

--- a/src/scripts/Textarea.js
+++ b/src/scripts/Textarea.js
@@ -16,12 +16,12 @@ export default class Textarea extends React.Component {
 
   validate(props, value) {
     const inputValue = (value !== undefined) ? value : props.value;
-    return ((inputValue !== null && inputValue.trim().length !== 0) ? true : false);
+    return ((inputValue !== undefined && inputValue !== null && inputValue.trim().length !== 0) ? true : false);
   }
 
   render() {
-    const { label, required, validate, validationMessage, ...props } = this.props;
-    const isValid = (validate === true) ? this.validate(this.props) : true;
+    const { label, required, validate, valid, validationMessage, ...props } = this.props;
+    const isValid = valid || (validate === true) ? this.validate(this.props) : true;
 
     if (label) {
       return (
@@ -50,6 +50,7 @@ Textarea.propTypes = {
   label: PropTypes.string,
   onChange: PropTypes.func,
   required: PropTypes.bool,
+  valid: PropTypes.bool,
   validate: PropTypes.bool,
   validationMessage: PropTypes.string,
 };


### PR DESCRIPTION
You can enable validation for Input & Textarea using the following syntax:

```javascript
<Input label='Name' placeholder='Name' value={ this.state.name } onChange={ this.onInputChange.bind(this, 'name') } required={true} validate={ this.state.validate } />
```

This enables me to:
- mark the element as mandatory using the required param
- force validation when I want by setting the validate param to true

The onChange event has an additional param passed to the event handler.  This param is used to indicate whether the input is valid.  This could be extended to be pluggable.