### PR TITLE
Fix Dropdown Button issue when unmounting

### DIFF
--- a/src/scripts/DropdownButton.js
+++ b/src/scripts/DropdownButton.js
@@ -64,7 +64,7 @@ export default class DropdownButton extends React.Component {
     if (!this.props.hoverPopup) {
       setTimeout(() => {
         const triggerElem = ReactDOM.findDOMNode(this.refs.trigger);
-        triggerElem.focus();
+        if (triggerElem) triggerElem.focus();
         this.setState({ opened: false });
       }, 10);
     }


### PR DESCRIPTION
If the component is getting unmounted at this point, no DOM node will be found and .trigger will fail.