### PR TITLE
Fix icon category is not reflected in "<category>:<icon>" notation

### DIFF
--- a/src/scripts/Icon.js
+++ b/src/scripts/Icon.js
@@ -73,7 +73,7 @@ export default class Icon extends React.Component {
 
   render() {
     const { container, ...props } = this.props;
-    let { category, icon } = this.props;
+    let { category, icon } = props;
 
     if (icon.indexOf(':') > 0) {
       [category, icon] = icon.split(':');
@@ -94,7 +94,7 @@ export default class Icon extends React.Component {
       );
     }
 
-    return this.renderSVG({ category, icon, ...props });
+    return this.renderSVG({ ...props, category, icon });
   }
 }
 

--- a/test/icon-spec.js
+++ b/test/icon-spec.js
@@ -1,0 +1,35 @@
+import assert from 'power-assert';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Icon from 'Icon';
+
+describe('Icon', () => {
+  it('should render icon', () => {
+    const icon = 'check';
+    const wrapper = shallow(<Icon icon={ icon } />);
+    assert(wrapper.hasClass('slds-icon'));
+    assert(wrapper.html().indexOf(`/assets/icons/utility-sprite/svg/symbols.svg#${icon}`) > 0);
+  });
+
+  it('should render icon with size', () => {
+    const size = 'small';
+    const wrapper = shallow(<Icon icon='icon' size={ size } />);
+    assert(wrapper.hasClass(`slds-icon--${size}`));
+  });
+
+  it('should render icon with category', () => {
+    const category = 'standard';
+    const icon = 'account';
+    const wrapper = shallow(<Icon category={ category } icon={ icon } />);
+    assert(wrapper.html().indexOf(`/assets/icons/${category}-sprite/svg/symbols.svg#${icon}`) > 0);
+  });
+
+  it('should render icon with category:icon notation', () => {
+    const category = 'action';
+    const icon = 'add_contact';
+    const categoryIcon = `${category}:${icon}`;
+    const wrapper = shallow(<Icon icon={ categoryIcon } />);
+    assert(wrapper.html().indexOf(`/assets/icons/${category}-sprite/svg/symbols.svg#${icon}`) > 0);
+  });
+});


### PR DESCRIPTION
When Icon's category is specified in `<Icon icon="<category>:<icon>" />` notation, category is not reflected and does not yield expected result.