### PR TITLE
Correct prop validation: ModalContent

### DIFF
--- a/src/scripts/Modal.js
+++ b/src/scripts/Modal.js
@@ -102,7 +102,7 @@ export class ModalContent extends Component {
 
 ModalContent.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 


### PR DESCRIPTION
ModalContent was throwing a validation error when multiple children were added to it.  Corrected to "Proptypes.node" to fix incorrect validation.