### PR TITLE
Fix tabmenu rendering in IE11

### DIFF
--- a/examples/public/index.html
+++ b/examples/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <link rel="stylesheet" href="./assets/styles/salesforce-lightning-design-system.css">
 </head>
 <body>

--- a/src/scripts/Tabs.js
+++ b/src/scripts/Tabs.js
@@ -12,7 +12,7 @@ export default class Tabs extends React.Component {
     registerStyle('tab-menu', [
       [
         '.slds-tabs__item.react-slds-tab-with-menu',
-        '{ position: relative !important; overflow: initial !important; }',
+        '{ position: relative !important; overflow: visible !important; }',
       ],
       [
         '.slds-tabs__item.react-slds-tab-with-menu > .react-slds-tab-item-inner',


### PR DESCRIPTION
In IE11 tab menu is hidden. Fix stylesheet `overflow` property.