### PR TITLE
Add support of error message and required indicator in form elements

### DIFF
--- a/examples/client/scripts/components/FormExamples.js
+++ b/examples/client/scripts/components/FormExamples.js
@@ -26,7 +26,13 @@ export default class FormExamples extends React.Component {
 
   onFieldChange(name, e, value) {
     console.log(name, value);
-    this.setState({ [name]: value });
+    this.setState({
+      [name]: value,
+      [`${name}Error`]:
+        (!value || value.length === 0 || String(value) === "2" ?
+         `${name} has an error in input` :
+         undefined),
+    });
   }
 
   render() {
@@ -36,32 +42,32 @@ export default class FormExamples extends React.Component {
         <h2 className='slds-m-vertical--medium'>Form Stacked</h2>
         <div style={ styles }>
           <Form>
-            <Input label='Text Field #1' type='text' placeholder='Input text here' />
-            <Input label='Number Field #1' type='number' placeholder='Input number here' />
-            <Textarea label='Textarea #1' defaultValue='Default Text' placeholder='Input text here' />
-            <RadioGroup label='Radio Group #1' name='radiogroup1'>
+            <Input label='Text Field #1' type='text' placeholder='Input text here' required />
+            <Input label='Number Field #1' type='number' placeholder='Input number here' required />
+            <Textarea label='Textarea #1' defaultValue='Default Text' placeholder='Input text here' required />
+            <RadioGroup label='Radio Group #1' name='radiogroup1' required>
               <Radio label='Radio #1' value={ 1 } />
               <Radio label='Radio #2' value={ 2 } defaultChecked />
               <Radio label='Radio #3' value={ 3 } disabled />
             </RadioGroup>
-            <CheckboxGroup label='Checkbox Group #1' name='checkgroup1'>
+            <CheckboxGroup label='Checkbox Group #1' name='checkgroup1' required>
               <Checkbox label='Check #1' value={ 1 } />
               <Checkbox label='Check #2' value={ 2 } defaultChecked />
               <Checkbox label='Check #3' value={ 3 } disabled />
             </CheckboxGroup>
-            <Select label='Select #1' defaultValue={ 2 }>
+            <Select label='Select #1' defaultValue={ 2 } required>
               <Option value={ 1 } label='Option #1' />
               <Option value={ 2 } >Option #2</Option>
               <Option value={ 3 } disabled >Option #3</Option>
             </Select>
-            <Picklist label='Picklist #1' menuSize='large'>
+            <Picklist label='Picklist #1' menuSize='large' required>
               <PicklistItem value={ 1 } label='Item #1' />
               <PicklistItem value={ 2 } >Item #2</PicklistItem>
               <PicklistItem value={ 3 } disabled >Item #3</PicklistItem>
               <PicklistItem value={ 4 }>Item #4</PicklistItem>
               <PicklistItem value={ 5 }>Item #5</PicklistItem>
             </Picklist>
-            <DateInput label='DateInput #1' defaultValue='2015-12-24' defaultOpened={false} />
+            <DateInput label='DateInput #1' defaultValue='2015-12-24' defaultOpened={false} required />
           </Form>
         </div>
 
@@ -70,15 +76,19 @@ export default class FormExamples extends React.Component {
           <Form type='horizontal'>
             <Input label='Text Field #1' value={ this.state.text } type='text' placeholder='Input text here'
               onChange={ this.onFieldChange.bind(this, 'text') }
+              required error={ this.state.textError }
             />
             <Input label='Number Field #1' value={ this.state.number } type='number' placeholder='Input number here'
               onChange={ this.onFieldChange.bind(this, 'number') }
+              required error={ this.state.numberError }
             />
             <Textarea label='Textarea #1' value={ this.state.textarea } placeholder='Input text here'
               onChange={ this.onFieldChange.bind(this, 'textarea') }
+              required error={ this.state.textareaError }
             />
             <RadioGroup label='Radio Group #1' name='radiogroup1'
               onChange={ this.onFieldChange.bind(this, 'radiogroup') }
+              required error={ this.state.radiogroupError }
             >
               <Radio label='Radio #1' value={ 1 } checked={ this.state.radiogroup === 1 } />
               <Radio label='Radio #2' value={ 2 } checked={ this.state.radiogroup === 2 } />
@@ -86,6 +96,7 @@ export default class FormExamples extends React.Component {
             </RadioGroup>
             <CheckboxGroup label='Checkbox Group #1' name='checkgroup1'
               onChange={ this.onFieldChange.bind(this, 'checkgroup') }
+              required error={ this.state.checkgroupError }
             >
               <Checkbox label='Check #1' value={ 1 } checked={ this.state.checkgroup.indexOf(1) >= 0 } />
               <Checkbox label='Check #2' value={ 2 } checked={ this.state.checkgroup.indexOf(2) >= 0 } />
@@ -93,6 +104,7 @@ export default class FormExamples extends React.Component {
             </CheckboxGroup>
             <Select label='Select #1' value={ this.state.select }
               onChange={ this.onFieldChange.bind(this, 'select') }
+              required error={ this.state.selectError }
             >
               <Option value={ 1 } label='Option #1' />
               <Option value={ 2 } >Option #2</Option>
@@ -100,6 +112,7 @@ export default class FormExamples extends React.Component {
             </Select>
             <Picklist label='Picklist #1' menuSize='small' value={ this.state.picklist }
               onValueChange={ (value) => this.onFieldChange('picklist', {}, value) }
+              required error={ this.state.picklistError }
             >
               { new Array(10).join('_').split('').map((a, i) => {
                 return <PicklistItem key={ i + 1 } value={ i + 1 } label={ 'Item #' + (i + 1) } disabled={ i % 3 === 0 } />;
@@ -107,6 +120,7 @@ export default class FormExamples extends React.Component {
             </Picklist>
             <DateInput label='DateInput #1' value={ this.state.dateinput }
               onValueChange={ (value) => this.onFieldChange('dateinput', {}, value) }
+              required error={ this.state.dateinputError }
             />
           </Form>
         </div>

--- a/examples/client/scripts/components/FormExamples.js
+++ b/examples/client/scripts/components/FormExamples.js
@@ -29,7 +29,7 @@ export default class FormExamples extends React.Component {
     this.setState({
       [name]: value,
       [`${name}Error`]:
-        (!value || value.length === 0 || String(value) === "2" ?
+        (!value || value.length === 0 || String(value) === '2' ?
          `${name} has an error in input` :
          undefined),
     });

--- a/src/scripts/Checkbox.js
+++ b/src/scripts/Checkbox.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
+import FormElement from './FormElement';
 
 
 export default class Checkbox extends React.Component {
@@ -16,13 +17,13 @@ export default class Checkbox extends React.Component {
   }
 
   render() {
-    const { grouped, ...props } = this.props;
+    const { grouped, required, error, ...props } = this.props;
     return (
       grouped ?
       this.renderCheckbox(props) :
-      <div className='slds-form-element'>
+      <FormElement required={ required } error={ error }>
         { this.renderCheckbox(props) }
-      </div>
+      </FormElement>
     );
   }
 
@@ -31,6 +32,14 @@ export default class Checkbox extends React.Component {
 Checkbox.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   name: PropTypes.string,
   value: PropTypes.any,
   grouped: PropTypes.bool,

--- a/src/scripts/CheckboxGroup.js
+++ b/src/scripts/CheckboxGroup.js
@@ -28,13 +28,23 @@ export default class CheckboxGroup extends React.Component {
   }
 
   render() {
-    const { className, label, totalCols, cols, style, onChange, children, ...props } = this.props;
+    const { className, label, totalCols, cols, style, required, error, onChange, children, ...props } = this.props;
     const grpClassNames = classnames(
       className,
       'slds-form-element',
+      {
+        'slds-has-error': error,
+        'slds-is-required': required,
+      },
       typeof totalCols === 'number' ? `slds-size--${cols || 1}-of-${totalCols}` : null
     );
     const grpStyles = typeof totalCols === 'number' ? { display: 'inline-block', ...style } : style;
+    const errorMessage =
+      error ?
+      (typeof error === 'string' ? error :
+       typeof error === 'object' ? error.message :
+       undefined) :
+      undefined;
     return (
       <fieldset className={ grpClassNames } style={ grpStyles } onChange={ this.onChange.bind(this) } { ...props } >
         <legend className='slds-form-element__label slds-form-element__label--top'>
@@ -43,6 +53,11 @@ export default class CheckboxGroup extends React.Component {
         <div className='slds-form-element__control' ref='controls'>
           { React.Children.map(children, this.renderControl.bind(this)) }
         </div>
+        {
+          errorMessage ?
+          <div className='slds-form-element__help'>{ errorMessage }</div> :
+          undefined
+        }
       </fieldset>
     );
   }
@@ -52,6 +67,14 @@ export default class CheckboxGroup extends React.Component {
 CheckboxGroup.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   name: PropTypes.string,
   totalCols: PropTypes.number,
   style: PropTypes.object,

--- a/src/scripts/DateInput.js
+++ b/src/scripts/DateInput.js
@@ -167,7 +167,11 @@ export default class DateInput extends React.Component {
   }
 
   render() {
-    const { totalCols, cols, label, defaultValue, value, dateFormat, onChange, onKeyDown, onBlur, ...props } = this.props;
+    const {
+      totalCols, cols, label, required, error,
+      defaultValue, value, dateFormat,
+      onChange, onKeyDown, onBlur, ...props,
+    } = this.props;
     const dateValue =
       typeof value !== 'undefined' ? value :
       typeof this.state.value !== 'undefined' ? this.state.value :
@@ -178,7 +182,7 @@ export default class DateInput extends React.Component {
       typeof dateValue !== 'undefined' && mvalue.isValid() ? mvalue.format(dateFormat) :
       null;
     const dropdown = this.renderDropdown(dateValue);
-    const formElemProps = { id: props.id, totalCols, cols, label, dropdown };
+    const formElemProps = { id: props.id, totalCols, cols, label, required, error, dropdown };
     return (
       <FormElement { ...formElemProps }>
         { this.renderInput({ inputValue, ...props }) }
@@ -198,6 +202,14 @@ DateInput.propTypes = {
   dateFormat: PropTypes.string,
   totalCols: PropTypes.number,
   cols: PropTypes.number,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   onChange: PropTypes.func,
   onValueChange: PropTypes.func,
   onComplete: PropTypes.func,

--- a/src/scripts/FormElement.js
+++ b/src/scripts/FormElement.js
@@ -22,7 +22,7 @@ export default class FormElement extends React.Component {
   }
 
   renderFormElement(props) {
-    const { className, label, totalCols, ...pprops } = props;
+    const { className, label, required, error, totalCols, ...pprops } = props;
     const inputId = props.id || this.state.id;
     if (typeof totalCols === 'number') {
       return (
@@ -36,9 +36,21 @@ export default class FormElement extends React.Component {
         </label>
       );
     }
-
+    const formElementClassNames = classnames(
+      'slds-form-element',
+      {
+        'slds-has-error': error,
+        'slds-is-required': required,
+      }
+    );
+    const errorMessage =
+      error ?
+      (typeof error === 'string' ? error :
+       typeof error === 'object' ? error.message :
+       undefined) :
+      undefined;
     return (
-      <div className='slds-form-element'>
+      <div className={ formElementClassNames }>
         {
           label ?
           <label className='slds-form-element__label' htmlFor={ inputId }>{ label }</label> :
@@ -47,6 +59,11 @@ export default class FormElement extends React.Component {
         <div className={ className }>
           { this.props.children }
         </div>
+        {
+          errorMessage ?
+          <span className='slds-form-element__help'>{ errorMessage }</span> :
+          undefined
+        }
       </div>
     );
   }
@@ -79,6 +96,9 @@ FormElement.propTypes = {
   id: PropTypes.string,
   dropdown: PropTypes.element,
   className: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.bool,
+  errorMessage: PropTypes.string,
   cols: PropTypes.number,
   children: PropTypes.element,
 };

--- a/src/scripts/Input.js
+++ b/src/scripts/Input.js
@@ -12,10 +12,10 @@ export default class Input extends React.Component {
   }
 
   render() {
-    const { label, ...props } = this.props;
-    if (label) {
+    const { label, required, error, ...props } = this.props;
+    if (label || required || error) {
       return (
-        <FormElement id={ props.id } label={ label }>
+        <FormElement id={ props.id } label={ label } required={ required } error={ error }>
           <Input { ...props } />
         </FormElement>
       );
@@ -36,6 +36,14 @@ export default class Input extends React.Component {
 Input.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   value: PropTypes.any,
   defaultValue: PropTypes.any,
   placeholder: PropTypes.string,

--- a/src/scripts/Picklist.js
+++ b/src/scripts/Picklist.js
@@ -164,9 +164,9 @@ export default class Picklist extends React.Component {
   }
 
   render() {
-    const { totalCols, cols, label, ...props } = this.props;
+    const { label, required, error, totalCols, cols, ...props } = this.props;
     const dropdown = this.renderDropdown();
-    const formElemProps = { id: props.id, totalCols, cols, label, dropdown };
+    const formElemProps = { id: props.id, label, required, error, totalCols, cols, dropdown };
     return (
       <FormElement { ...formElemProps }>
         { this.renderPicklist(props) }
@@ -179,6 +179,14 @@ export default class Picklist extends React.Component {
 Picklist.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   name: PropTypes.string,
   value: PropTypes.any,
   defaultValue: PropTypes.any,

--- a/src/scripts/RadioGroup.js
+++ b/src/scripts/RadioGroup.js
@@ -18,13 +18,23 @@ export default class RadioGroup extends React.Component {
   }
 
   render() {
-    const { className, label, totalCols, cols, style, onChange, children, ...props } = this.props;
+    const { className, label, required, error, totalCols, cols, style, onChange, children, ...props } = this.props;
     const grpClassNames = classnames(
       className,
       'slds-form-element',
+      {
+        'slds-has-error': error,
+        'slds-is-required': required,
+      },
       typeof totalCols === 'number' ? `slds-size--${cols || 1}-of-${totalCols}` : null
     );
     const grpStyles = typeof totalCols === 'number' ? { display: 'inline-block', ...style } : style;
+    const errorMessage =
+      error ?
+      (typeof error === 'string' ? error :
+       typeof error === 'object' ? error.message :
+       undefined) :
+      undefined;
     return (
       <fieldset className={ grpClassNames } style={ grpStyles } { ...props } >
         <legend className='slds-form-element__label slds-form-element__label--top'>
@@ -33,6 +43,11 @@ export default class RadioGroup extends React.Component {
         <div className='slds-form-element__control'>
           { React.Children.map(children, this.renderControl.bind(this)) }
         </div>
+        {
+          errorMessage ?
+          <div className='slds-form-element__help'>{ errorMessage }</div> :
+          undefined
+        }
       </fieldset>
     );
   }
@@ -42,6 +57,14 @@ export default class RadioGroup extends React.Component {
 RadioGroup.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   name: PropTypes.string,
   onChange: PropTypes.func,
   totalCols: PropTypes.number,

--- a/src/scripts/Select.js
+++ b/src/scripts/Select.js
@@ -12,10 +12,10 @@ export default class Select extends React.Component {
   }
 
   render() {
-    const { label, ...props } = this.props;
-    if (label) {
+    const { label, required, error, ...props } = this.props;
+    if (label || required || error) {
       return (
-        <FormElement id={ props.id } label={ label }>
+        <FormElement id={ props.id } label={ label } required={ required } error={ error }>
           <Select { ...props } />
         </FormElement>
       );
@@ -35,8 +35,16 @@ export default class Select extends React.Component {
 }
 
 Select.propTypes = {
-  label: PropTypes.string,
   className: PropTypes.string,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   value: PropTypes.any,
   defaultValue: PropTypes.any,
   placeholder: PropTypes.string,

--- a/src/scripts/Textarea.js
+++ b/src/scripts/Textarea.js
@@ -12,10 +12,10 @@ export default class Textarea extends React.Component {
   }
 
   render() {
-    const { label, ...props } = this.props;
-    if (label) {
+    const { label, required, error, ...props } = this.props;
+    if (label || required || error) {
       return (
-        <FormElement>
+        <FormElement id={ props.id } label={ label } required={ required } error={ error }>
           <Textarea { ...props } />
         </FormElement>
       );
@@ -34,9 +34,17 @@ export default class Textarea extends React.Component {
 
 Textarea.propTypes = {
   className: PropTypes.string,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   value: PropTypes.string,
   defaultValue: PropTypes.string,
   placeholder: PropTypes.string,
-  label: PropTypes.string,
   onChange: PropTypes.func,
 };


### PR DESCRIPTION
In this PR it adds support of required indicator (*) in form element fields by `required` property.
It also adds error message in `error` property when it has any errors (e.g. validation failure).

This is coming from #29, but differs bacause it is not including any validation logic inside.
Component users should care about it and add any validation or error detection logic outside of the components.