### PR TITLE
Fixed proptypes in FormElement and required indication in Lookup

### DIFF
--- a/src/scripts/FormElement.js
+++ b/src/scripts/FormElement.js
@@ -97,8 +97,13 @@ FormElement.propTypes = {
   dropdown: PropTypes.element,
   className: PropTypes.string,
   required: PropTypes.bool,
-  error: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   cols: PropTypes.number,
   children: PropTypes.element,
 };

--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -392,7 +392,8 @@ export default class Lookup extends Component {
 
   render() {
     const {
-      totalCols, cols, label,
+      totalCols, cols,
+      label, required, error,
       className,
       selected = this.state.selected, defaultSelected,
       opened = this.state.opened, defaultOpened,
@@ -415,7 +416,7 @@ export default class Lookup extends Component {
         onBlur={ this.onBlur.bind(this) }
       />
     );
-    const formElemProps = { id: props.id, totalCols, cols, label, dropdown };
+    const formElemProps = { id: props.id, totalCols, cols, label, required, error, dropdown };
     return (
       <FormElement { ...formElemProps }>
         <div className={ className }>
@@ -445,6 +446,14 @@ export default class Lookup extends Component {
 Lookup.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.shape({
+      message: PropTypes.string,
+    }),
+  ]),
   value: PropTypes.string,
   defaultValue: PropTypes.string,
   selected: LookupEntryType,


### PR DESCRIPTION
This fixes a warning when passing an actual error (e.g string) to FormElement, and enables `required` and `error` props in Lookup element.