### PR TITLE
Ability to hard-code Icon symbol file paths based on Cateogy

### DIFF
--- a/src/scripts/Icon.js
+++ b/src/scripts/Icon.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import svg4everybody from 'svg4everybody';
-import util from './util';
+import { getAssetRoot, getSymbolsFilePath } from './util';
 
 svg4everybody();
 
@@ -35,6 +35,10 @@ export default class Icon extends React.Component {
     );
   }
 
+  getSymbolsSvg(category) {
+    return getSymbolsFilePath(category) || `${ getAssetRoot() }/icons/${category}-sprite/svg/symbols.svg`;
+  }
+
   checkIconColor() {
     const { fillColor, category = 'utility', container } = this.props;
     if (fillColor === 'none' || category === 'doctype' || (!fillColor && category === 'utility')) {
@@ -61,7 +65,9 @@ export default class Icon extends React.Component {
       },
       className
     );
-    const useHtml = `<use xlink:href="${ util.getAssetRoot() }/icons/${category}-sprite/svg/symbols.svg#${icon}"></use>`;
+
+    const useHtml = `<use xlink:href="${this.getSymbolsSvg(category)}#${icon}"></use>`;
+
     return (
       <svg className={ iconClassNames }
         aria-hidden

--- a/src/scripts/util.js
+++ b/src/scripts/util.js
@@ -47,4 +47,4 @@ export function registerStyle(styleName, rules) {
   }
 }
 
-export default { setAssetRoot, getAssetRoot, registerStyle };
+export default { setAssetRoot, getAssetRoot, registerStyle, getSymbolsFilePath, setSymbolsFilePath };

--- a/src/scripts/util.js
+++ b/src/scripts/util.js
@@ -1,4 +1,5 @@
 let assetRoot = '/assets';
+const symbolFiles = {};
 
 export function setAssetRoot(path) {
   assetRoot = path;
@@ -6,6 +7,27 @@ export function setAssetRoot(path) {
 
 export function getAssetRoot() {
   return assetRoot;
+}
+
+export function clearSymbolPaths() {
+  Object.keys(symbolFiles).forEach(key => {
+    delete symbolFiles[key];
+  });
+}
+
+export function getAllSymbolsPaths() {
+  return symbolFiles;
+}
+
+// get the file path for a single symbols file by type
+export function getSymbolsFilePath(type) {
+  return symbolFiles[type];
+}
+
+// updates the symbols file object by assigning
+// all differences passed in
+export function setSymbolsFilePath(updates) {
+  return Object.assign(symbolFiles, updates);
 }
 
 export function registerStyle(styleName, rules) {

--- a/test/icon-spec.js
+++ b/test/icon-spec.js
@@ -1,6 +1,7 @@
 import assert from 'power-assert';
 import React from 'react';
 import { shallow } from 'enzyme';
+import { setSymbolsFilePath } from '../src/scripts/util';
 
 import Icon from 'Icon';
 
@@ -31,5 +32,16 @@ describe('Icon', () => {
     const categoryIcon = `${category}:${icon}`;
     const wrapper = shallow(<Icon icon={ categoryIcon } />);
     assert(wrapper.html().indexOf(`/assets/icons/${category}-sprite/svg/symbols.svg#${icon}`) > 0);
+  });
+
+  it('should render the icon using a preset symbols path for a given type', () => {
+    const category = 'action';
+    const icon = 'do_something';
+    const categoryIcon = `${category}:${icon}`;
+
+    setSymbolsFilePath({ action: '/this/is/not/a/real/path.svg' });
+
+    const wrapper = shallow(<Icon icon={ categoryIcon } />);
+    assert(wrapper.html().indexOf(`/this/is/not/a/real/path.svg#${icon}`) > 0);
   });
 });

--- a/test/util-spec.js
+++ b/test/util-spec.js
@@ -2,7 +2,6 @@ import { setSymbolsFilePath, getSymbolsFilePath, clearSymbolPaths } from '../src
 import assert from 'power-assert';
 
 describe('util', () => {
-
   beforeEach(() => {
     clearSymbolPaths();
   });
@@ -11,7 +10,7 @@ describe('util', () => {
     it('should update the symbol file paths based on the object passed in', () => {
       const expected = {
         foo: 'bar/symbols.svg',
-        other: 'thing/is/in/some/path/banan'
+        other: 'thing/is/in/some/path/banan',
       };
 
       const result = setSymbolsFilePath(expected);
@@ -24,7 +23,7 @@ describe('util', () => {
     it('should append changes to the list of symbols and update existing', () => {
       const expected = {
         foo: 'bar/symbols.svg',
-        other: 'thing/is/in/some/path/banan'
+        other: 'thing/is/in/some/path/banan',
       };
 
       setSymbolsFilePath(expected);
@@ -46,7 +45,7 @@ describe('util', () => {
     it('should get a set symbols file path', () => {
       const expected = {
         foo: 'bar/symbols.svg',
-        other: 'thing/is/in/some/path/banan'
+        other: 'thing/is/in/some/path/banan',
       };
 
       setSymbolsFilePath(expected);
@@ -56,4 +55,4 @@ describe('util', () => {
       assert(getSymbolsFilePath('dne') === undefined);
     });
   });
-})
+});

--- a/test/util-spec.js
+++ b/test/util-spec.js
@@ -1,0 +1,59 @@
+import { setSymbolsFilePath, getSymbolsFilePath, clearSymbolPaths } from '../src/scripts/util';
+import assert from 'power-assert';
+
+describe('util', () => {
+
+  beforeEach(() => {
+    clearSymbolPaths();
+  });
+
+  describe('setSymbolsFilePath', () => {
+    it('should update the symbol file paths based on the object passed in', () => {
+      const expected = {
+        foo: 'bar/symbols.svg',
+        other: 'thing/is/in/some/path/banan'
+      };
+
+      const result = setSymbolsFilePath(expected);
+
+      assert(result.foo === 'bar/symbols.svg');
+      assert(result.other === 'thing/is/in/some/path/banan');
+      assert(Object.keys(result).length === 2);
+    });
+
+    it('should append changes to the list of symbols and update existing', () => {
+      const expected = {
+        foo: 'bar/symbols.svg',
+        other: 'thing/is/in/some/path/banan'
+      };
+
+      setSymbolsFilePath(expected);
+
+      expected.foo = 'foo.svg';
+      expected.newThing = 'some/new.thing.svg';
+
+      const result = setSymbolsFilePath(expected);
+
+
+      assert(result.foo === 'foo.svg');
+      assert(result.other === 'thing/is/in/some/path/banan');
+      assert(result.newThing === 'some/new.thing.svg');
+      assert(Object.keys(result).length === 3);
+    });
+  });
+
+  describe('getSymbolsFilePath', () => {
+    it('should get a set symbols file path', () => {
+      const expected = {
+        foo: 'bar/symbols.svg',
+        other: 'thing/is/in/some/path/banan'
+      };
+
+      setSymbolsFilePath(expected);
+
+      assert(getSymbolsFilePath('foo') === 'bar/symbols.svg');
+      assert(getSymbolsFilePath('other') === 'thing/is/in/some/path/banan');
+      assert(getSymbolsFilePath('dne') === undefined);
+    });
+  });
+})


### PR DESCRIPTION
# updates to util.js

### New Function : setSymbolsFilePath
- updates the symbol file paths with an object of updates. the updates object should take the form:
`{ category: 'file_path' }`
- if a category is already defined, it is updated
- if new categories are being passed in, the previously set categories are left in-tact and the new categories are added

### New Function : getSymbolsFilePath
- gets the file path for some set category. returns the file path as a string if it has been assigned for the provided category, false otherwise.

### New Function : getAllSymbolsPaths
- returns the entire symbol paths object

### New Function : clearSymbolPaths
- removes all previously set symbol paths.

# updates to Icon.js

### Updated Function : renderSVG
- renderSVG now calls this.getSymbolsSvg to get the correct path for the symbols file. #${icon} is still appended

### New Function : getSymbolsSvg
- retrieves eithe the set symbols path (if available) or defaults to the <ASSET_ROOT>/icons/<CATEGORY>-sprite/svg/symbols.svg