### PR TITLE
Fixed Lookup dropdown to support slds versions before and after 2.0.0

### DIFF
--- a/src/scripts/Lookup.js
+++ b/src/scripts/Lookup.js
@@ -341,7 +341,7 @@ class LookupCandidateList extends Component {
     const { data = [], hidden, loading, header, footer, filter = () => true } = this.props;
     const lookupMenuClassNames = classnames(
       'slds-lookup__menu',
-      { 'slds-hide': hidden }
+      { 'slds-hide': hidden, 'slds-show': !hidden }
     );
     return (
       <div className={ lookupMenuClassNames } role='listbox'


### PR DESCRIPTION
Starting on SLDS 2.0.0 (https://github.com/salesforce-ux/design-system/commit/29152bb59499f2522f9ce40d2b646d5c874abc52), the component `slds-lookup__menu` is hidden by default. The official way of making it visible when needed is adding `slds-is-open` to its `slds-lookup` *parent*. 
Since in this project `slds-lookup__menu` isn't the child of `slds-lookup`, and to support both PRE and POST slds-2.0.0, I've added a simple class to make the dropdown visible when needed.