### PR TITLE
improvement order of days in week for other locales

### DIFF
--- a/src/scripts/Datepicker.js
+++ b/src/scripts/Datepicker.js
@@ -172,10 +172,10 @@ export default class Datepicker extends React.Component {
         <thead>
           <tr>
             {
-              moment.weekdaysMin().map((wd, i) => {
+              moment.weekdaysMin(true).map((wd, i) => {
                 return (
                   <th key={ i }>
-                    <abbr title={ moment.weekdays(i) }>{ wd }</abbr>
+                    <abbr title={ moment.weekdays(true, i) }>{ wd }</abbr>
                   </th>
                 );
               })


### PR DESCRIPTION
Way to reproduce bug:
1. Update location:
moment.updateLocale ('pl');
2. Display calendar.

This problem concerns days of the week on the top bar of the calendar that did not agree with the actual dates (for example, 14.06 is described as Monday in pol lang).

Fix also improves displaying correctly 'first day of week’ (Monday for non-USA).